### PR TITLE
chore: update example to mitigate repo lock issue

### DIFF
--- a/examples/full-s3-repo/index.js
+++ b/examples/full-s3-repo/index.js
@@ -27,7 +27,8 @@ const repo = new Repo('/tmp/test/.ipfs', {
     blocks: { s3 },
     keys: { s3 },
     datastore: { s3 }
-  }
+  },
+  lock: 'memory'
 })
 
 let node = new IPFS({


### PR DESCRIPTION
Fixes an issue with the example where the repo lock is being managed by fs

work around for ipfs/js-datastore-s3#1