### PR TITLE
fix: callback called twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "async": "^2.6.1",
     "datastore-core": "~0.6.0",
     "interface-datastore": "~0.6.0",
+    "once": "^1.4.0",
     "pull-defer": "~0.2.3",
     "pull-stream": "^3.6.9",
     "upath": "^1.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 /* :: import type {Batch, Query, QueryResult, Callback} from 'interface-datastore' */
 const assert = require('assert')
 const path = require('upath')
-const setImmediate = require('async/setImmediate')
+const nextTick = require('async/nextTick')
 const each = require('async/each')
 const waterfall = require('async/series')
 const asyncFilter = require('interface-datastore').utils.asyncFilter
@@ -95,7 +95,7 @@ class S3Datastore {
       if (err && err.code === 'NoSuchBucket' && this.createIfMissing) {
         return this.opts.s3.createBucket({}, (err) => {
           if (err) return callback(err)
-          setImmediate(() => this.put(key, val, callback))
+          nextTick(() => this.put(key, val, callback))
         })
       } else if (err) {
         return callback(Errors.dbWriteFailedError(err))
@@ -367,7 +367,7 @@ class S3Datastore {
    * @returns {void}
    */
   close (callback /* : (err: ?Error) => void */) /* : void */ {
-    setImmediate(callback)
+    nextTick(callback)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
 const assert = require('assert')
 const path = require('upath')
 const nextTick = require('async/nextTick')
+const once = require('once')
 const each = require('async/each')
 const waterfall = require('async/series')
 const asyncFilter = require('interface-datastore').utils.asyncFilter
@@ -88,6 +89,7 @@ class S3Datastore {
    * @returns {void}
    */
   put (key /* : Key */, val /* : Buffer */, callback /* : Callback<void> */) /* : void */ {
+    callback = once(callback)
     this.opts.s3.upload({
       Key: this._getFullKey(key),
       Body: val
@@ -113,6 +115,7 @@ class S3Datastore {
    * @returns {void}
    */
   get (key /* : Key */, callback /* : Callback<Buffer> */) /* : void */ {
+    callback = once(callback)
     this.opts.s3.getObject({
       Key: this._getFullKey(key)
     }, (err, data) => {
@@ -135,6 +138,7 @@ class S3Datastore {
    * @returns {void}
    */
   has (key /* : Key */, callback /* : Callback<bool> */) /* : void */ {
+    callback = once(callback)
     this.opts.s3.headObject({
       Key: this._getFullKey(key)
     }, (err, data) => {
@@ -156,6 +160,7 @@ class S3Datastore {
    * @returns {void}
    */
   delete (key /* : Key */, callback /* : Callback<void> */) /* : void */ {
+    callback = once(callback)
     this.opts.s3.deleteObject({
       Key: this._getFullKey(key)
     }, (err) => {
@@ -182,6 +187,7 @@ class S3Datastore {
         deletes.push(key)
       },
       commit: (callback /* : (err: ?Error) => void */) => {
+        callback = once(callback)
         waterfall([
           (cb) => each(puts, (p, _cb) => {
             this.put(p.key, p.value, _cb)
@@ -207,6 +213,7 @@ class S3Datastore {
       keys = []
     }
 
+    callback = once(callback)
     this.opts.s3.listObjectsV2(params, (err, data) => {
       if (err) {
         return callback(new Error(err.code))
@@ -241,6 +248,8 @@ class S3Datastore {
 
     return {
       next: (callback/* : Callback<Error, Key, Buffer> */) => {
+        callback = once(callback)
+
         // Check if we're done
         if (count >= keys.length) {
           return callback(null, null, null)
@@ -278,6 +287,8 @@ class S3Datastore {
 
     // this gets called recursively, the internals need to iterate
     const rawStream = (end, callback) => {
+      callback = once(callback)
+
       if (end) {
         return callback(end)
       }
@@ -346,6 +357,7 @@ class S3Datastore {
    * @returns {void}
    */
   open (callback /* : Callback<void> */) /* : void */ {
+    callback = once(callback)
     this.opts.s3.headObject({
       Key: this.path
     }, (err, data) => {


### PR DESCRIPTION
**Callback called twice**

Fixes #12.

The aws api is unreliable with its errors. It's currently
possible for a call to succeed, call the callback, and then
later receive a connection error which is passed to the
already called callback. This results in callback called
twice errors. Leveraging once will prevent these errors from
the aws api.

**nextTick**
This also switches to use nextTick instead of setImmediate as the former is more performant.
