### PR TITLE
fix(createRepo): pass sub paths in repo to each store

### DIFF
--- a/src/s3-repo.js
+++ b/src/s3-repo.js
@@ -69,25 +69,17 @@ const createRepo = (S3Store, options, s3Options) => {
     createIfMissing
   }
 
-  const store = new S3Store(path, storeConfig)
-
-  class Store {
-    constructor () {
-      return store
-    }
-  }
-
   // If no lock is given, create a mock lock
   lock = lock || notALock
 
   return new IPFSRepo(path, {
     storageBackends: {
-      root: Store,
-      blocks: Store,
-      keys: Store,
-      datastore: Store
+      root: S3Store,
+      blocks: S3Store,
+      keys: S3Store,
+      datastore: S3Store
     },
-    storageBackendconfig: {
+    storageBackendOptions: {
       root: storeConfig,
       blocks: storeConfig,
       keys: storeConfig,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -185,7 +185,7 @@ describe('S3Datastore', () => {
 
   describe('createRepo', () => {
     it('should be able to create a repo', () => {
-      const path = '.ipfs/datastore'
+      const path = '.ipfs'
       const repo = createRepo({
         path
       }, {


### PR DESCRIPTION
createRepo was passing repo path, as path to each data store. So repo would be '.ipfs' and then blocks datastore would also be passed '.ipfs' instead of '.ipfs/blocks'

This fix allows correct sub repo paths to be passed through to each store in lines below. 
https://github.com/ipfs/js-ipfs-repo/blob/master/src/index.js#L107
https://github.com/ipfs/js-ipfs-repo/blob/master/src/backends.js#L6

Also changes  storageBackendconfig -> storageBackendOptions to match option names in ipfs repo so that s3 obj can be passed through. 
