### PR TITLE
chore: use ipfs 0.39 and repo 0.29

### DIFF
--- a/examples/full-s3-repo/index.js
+++ b/examples/full-s3-repo/index.js
@@ -3,25 +3,24 @@
 const IPFS = require('ipfs')
 const { createRepo } = require('datastore-s3')
 
-// Create the repo
-const s3Repo = createRepo({
-  path: '/tmp/test/.ipfs'
-}, {
-  bucket: 'my-bucket',
-  accessKeyId: 'myaccesskey',
-  secretAccessKey: 'mysecretkey'
-})
+;(async () => {
+  // Create the repo
+  const s3Repo = createRepo({
+    path: '/tmp/test/.ipfs'
+  }, {
+    bucket: 'my-bucket',
+    accessKeyId: 'myaccesskey',
+    secretAccessKey: 'mysecretkey'
+  })
 
-// Create a new IPFS node with our S3 backed Repo
-let node = new IPFS({
-  repo: s3Repo
-})
+  // Create a new IPFS node with our S3 backed Repo
+  console.log('Start ipfs')
+  const node = await IPFS.create({
+    repo: s3Repo
+  })
 
-console.log('Start the node')
-
-// Test out the repo by sending and fetching some data
-node.on('ready', async () => {
-  console.log('Ready')
+  // Test out the repo by sending and fetching some data
+  console.log('IPFS is ready')
 
   try {
     const version = await node.version()
@@ -36,7 +35,7 @@ node.on('ready', async () => {
 
     // Log out the added files metadata and cat the file from IPFS
     const data = await node.cat(filesAdded[0].hash)
-    
+
     // Print out the files contents to console
     console.log(`\nFetched file content containing ${data.byteLength} bytes`)
   } catch (err) {
@@ -46,5 +45,5 @@ node.on('ready', async () => {
   // After everything is done, shut the node down
   // We don't need to worry about catching errors here
   console.log('\n\nStopping the node')
-  return node.stop()
-})
+  await node.stop()
+})()

--- a/examples/full-s3-repo/package.json
+++ b/examples/full-s3-repo/package.json
@@ -10,9 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.402.0",
+    "aws-sdk": "^2.579.0",
     "datastore-s3": "../../",
-    "ipfs": "~0.34.4",
-    "ipfs-repo": "~0.26.1"
+    "ipfs": "^0.39.0",
+    "ipfs-repo": "~0.29.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,18 +42,18 @@
     "upath": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.0.0",
-    "aws-sdk": "^2.510.0",
+    "aegir": "^20.4.1",
+    "aws-sdk": "^2.579.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "flow-bin": "^0.93.0",
     "flow-typed": "^2.5.1",
-    "ipfs-repo": "^0.27.0",
+    "ipfs-repo": "^0.29.2",
     "stand-in": "^4.2.0"
   },
   "peerDependencies": {
     "aws-sdk": "2.x",
-    "ipfs-repo": "^0.27.0"
+    "ipfs-repo": "^0.29.0"
   },
   "contributors": [
     "Andrew Nesbitt <andrewnez@gmail.com>",


### PR DESCRIPTION
This updates the example to use the async ipfs-repo and ipfs 0.39 which uses the async repo.

Resolves #20, #21 

