### PR TITLE
feat: adds interface-datastore streaming api

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,19 +36,18 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-s3#readme",
   "dependencies": {
-    "datastore-core": "^0.7.0",
-    "interface-datastore": "^0.7.0",
-    "streaming-iterables": "^4.1.0",
+    "datastore-core": "^1.1.0",
+    "interface-datastore": "^1.0.2",
     "upath": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.4.1",
+    "aegir": "^22.0.0",
     "aws-sdk": "^2.579.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "flow-bin": "^0.93.0",
     "flow-typed": "^2.5.1",
-    "ipfs-repo": "^0.29.2",
+    "ipfs-repo": "^2.1.1",
     "stand-in": "^4.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Uses the Adapter from interface-datastore to support the new streaming api for puts/get/etc.

Removes duplicated code that has been pushed up into the adapter and uses the async utils from interface-datastore instead of the streaming-iterables dep which can now be removed.