### PR TITLE
Lightweight S3 caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ dist
 docs
 
 .idea
+.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ node_modules
 lib
 dist
 docs
+
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ $ npm install datastore-s3
 ## Usage
 If the flag `createIfMissing` is not set or is false, then the bucket must be created prior to using datastore-s3. Please see the AWS docs for information on how to configure the S3 instance. A bucket name is required to be set at the s3 instance level, see the below example.
 
+The cache is disabled by default. In order to enable it pass the `cacheEnabled` flag.
+
 ```js
 const S3 = require('aws-sdk').S3
 const s3Instance = new S3({ params: { Bucket: 'my-ipfs-bucket' } })

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "buffer": "^5.6.0",
     "datastore-core": "^1.1.0",
-    "interface-datastore": "^1.0.2"
+    "interface-datastore": "^1.0.2",
+    "js-cache": "^1.0.3"
   },
   "devDependencies": {
     "aegir": "^24.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const { Buffer } = require('buffer')
 
-const cache = require('js-cache');
+const cache = require('js-cache')
 
 const {
   Adapter,
@@ -61,7 +61,9 @@ class S3Datastore extends Adapter {
 
     if (this.cacheEnabled) {
       this.cacheTTL = cacheTTL
+      // eslint-disable-next-line new-cap
       this.s3DataCache = new cache() // create cache for values
+      // eslint-disable-next-line new-cap
       this.s3HeadCache = new cache() // create cache for HEAD results
     }
   }
@@ -105,18 +107,18 @@ class S3Datastore extends Adapter {
    * @returns {Promise<Buffer>}
    */
   async get (key) {
-    let data = this.getFromCache(this.s3DataCache, key)
+    const data = this.getFromCache(this.s3DataCache, key)
     if (data !== undefined) {
       return data
     }
 
     try {
-      let data = await this.opts.s3.getObject({
+      const data = await this.opts.s3.getObject({
         Key: this._getFullKey(key)
       }).promise()
 
       // If a body was returned, ensure it's a Buffer
-      let result = data.Body ? Buffer.from(data.Body) : null
+      const result = data.Body ? Buffer.from(data.Body) : null
       this.putToCache(this.s3DataCache, key, result)
       return result
     } catch (err) {
@@ -131,11 +133,11 @@ class S3Datastore extends Adapter {
 
   /**
    * Gets value stored in cache
-   * @param cache - Cache instance
-   * @param key - Key
+   * @param {Cache} cache Cache instance
+   * @param {string} key Key
    * @return {undefined|*}
    */
-  getFromCache(cache, key) {
+  getFromCache (cache, key) {
     if (!this.cacheEnabled) {
       return undefined
     }
@@ -143,7 +145,6 @@ class S3Datastore extends Adapter {
     const fullKey = this._getFullKey(key)
     const data = cache.get(fullKey)
     if (data !== undefined) {
-      console.log(`Got value for ${fullKey} from cache`)
       if (data instanceof Error) {
         throw data
       }
@@ -153,29 +154,26 @@ class S3Datastore extends Adapter {
 
   /**
    * Puts value into cache
-   * @param cache - Cache instance
-   * @param key - Key
-   * @param value - Value
-   * @param ttl - Time to live
+   * @param {Cache} cache Cache instance
+   * @param {Key} key Key
+   * @param {Object} value Value
+   * @param {Number} ttl Time to live
    */
-  putToCache(cache, key, value, ttl) {
+  putToCache (cache, key, value, ttl) {
     if (!this.cacheEnabled) {
       return
     }
 
     const fullKey = this._getFullKey(key)
-    console.log(`Put value for ${fullKey} to cache`)
-
-    const timeToLive = ttl? ttl : this.cacheTTL
-    cache.set(this._getFullKey(key), value, timeToLive)
+    cache.set(fullKey, value, ttl || this.cacheTTL)
   }
 
   /**
    * Deletes value from cache
-   * @param cache - Cache instance
-   * @param key - Key
+   * @param {Cache} cache Cache instance
+   * @param {Key} key Key
    */
-  delFromCache(cache, key) {
+  delFromCache (cache, key) {
     if (!this.cacheEnabled) {
       return
     }

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ class S3Datastore extends Adapter {
   async has (key) {
     const result = this.getFromCache(this.cache, key)
     if (result !== undefined) {
-      return result
+      return true
     }
 
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class S3Datastore extends Adapter {
    * @param {Object} value Value
    * @param {Number} ttl Time to live
    */
-  putToCache (cache, key, value, ttl= DEFAULT_CACHE_TTL) {
+  putToCache (cache, key, value, ttl = DEFAULT_CACHE_TTL) {
     if (!this.cacheEnabled) {
       return
     }

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ class S3Datastore extends Adapter {
     if (!this.cacheEnabled) {
       return
     }
-    cache.del(key)
+    cache.del(this._getFullKey(key))
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
 
 const { Buffer } = require('buffer')
 
+const cache = require('js-cache');
+
 const {
   Adapter,
   Key,
@@ -11,6 +13,10 @@ const {
   }
 } = require('interface-datastore')
 const createRepo = require('./s3-repo')
+
+const DEFAULT_CACHE_TTL = 10000 // 10 seconds
+
+const DEFAULT_404_CACHE_TTL = 2000 // 2 seconds
 
 /**
  * A datastore backed by the file system.
@@ -25,6 +31,8 @@ class S3Datastore extends Adapter {
     this.path = path
     this.opts = opts
     const {
+      cacheEnabled = false,
+      cacheTTL = DEFAULT_CACHE_TTL,
       createIfMissing = false,
       s3: {
         config: {
@@ -41,8 +49,21 @@ class S3Datastore extends Adapter {
     if (typeof createIfMissing !== 'boolean') {
       throw new Error(`createIfMissing must be a boolean but was (${typeof createIfMissing}) ${createIfMissing}`)
     }
+    if (typeof cacheEnabled !== 'boolean') {
+      throw new Error(`cacheEnabled must be a boolean but was (${typeof cacheEnabled}) ${cacheEnabled}`)
+    }
+    if (typeof cacheTTL !== 'number') {
+      throw new Error(`cacheTTL must be a number but was (${typeof cacheTTL}) ${cacheTTL}`)
+    }
     this.bucket = Bucket
     this.createIfMissing = createIfMissing
+    this.cacheEnabled = cacheEnabled
+
+    if (this.cacheEnabled) {
+      this.cacheTTL = cacheTTL
+      this.s3DataCache = new cache() // create cache for values
+      this.s3HeadCache = new cache() // create cache for HEAD results
+    }
   }
 
   /**
@@ -84,19 +105,76 @@ class S3Datastore extends Adapter {
    * @returns {Promise<Buffer>}
    */
   async get (key) {
+    let data = this.getFromCache(this.s3DataCache, key)
+    if (data !== undefined) {
+      return data
+    }
+
     try {
-      const data = await this.opts.s3.getObject({
+      let data = await this.opts.s3.getObject({
         Key: this._getFullKey(key)
       }).promise()
 
       // If a body was returned, ensure it's a Buffer
-      return data.Body ? Buffer.from(data.Body) : null
+      let result = data.Body ? Buffer.from(data.Body) : null
+      this.putToCache(this.s3DataCache, key, result)
+      return result
     } catch (err) {
       if (err.statusCode === 404) {
-        throw Errors.notFoundError(err)
+        const wrappedErr = Errors.notFoundError(err)
+        this.putToCache(this.s3DataCache, key, wrappedErr, DEFAULT_404_CACHE_TTL)
+        throw wrappedErr
       }
       throw err
     }
+  }
+
+  /**
+   * Gets value stored in cache
+   * @param cache - Cache instance
+   * @param key - Key
+   * @return {undefined|*}
+   */
+  getFromCache(cache, key) {
+    if (!this.cacheEnabled) {
+      return undefined
+    }
+
+    const data = cache.get(this._getFullKey(key))
+    if (data !== undefined) {
+      if (data instanceof Error) {
+        throw data
+      }
+      return data
+    }
+  }
+
+  /**
+   * Puts value into cache
+   * @param cache - Cache instance
+   * @param key - Key
+   * @param value - Value
+   * @param ttl - Time to live
+   */
+  putToCache(cache, key, value, ttl) {
+    if (!this.cacheEnabled) {
+      return
+    }
+
+    const timeToLive = ttl? ttl : this.cacheTTL
+    cache.set(this._getFullKey(key), value, timeToLive)
+  }
+
+  /**
+   * Deletes value from cache
+   * @param cache - Cache instance
+   * @param key - Key
+   */
+  delFromCache(cache, key) {
+    if (!this.cacheEnabled) {
+      return
+    }
+    cache.del(key)
   }
 
   /**
@@ -106,13 +184,21 @@ class S3Datastore extends Adapter {
    * @returns {Promise<bool>}
    */
   async has (key) {
+    const result = this.getFromCache(this.s3HeadCache, key)
+    if (result !== undefined) {
+      return result
+    }
+
     try {
       await this.opts.s3.headObject({
         Key: this._getFullKey(key)
       }).promise()
+
+      this.putToCache(this.s3HeadCache, key, true)
       return true
     } catch (err) {
       if (err.code === 'NotFound') {
+        this.putToCache(this.s3HeadCache, key, false, DEFAULT_404_CACHE_TTL)
         return false
       }
       throw err
@@ -127,6 +213,11 @@ class S3Datastore extends Adapter {
    */
   async delete (key) {
     try {
+      if (this.cacheEnabled) {
+        this.delFromCache(this.s3DataCache, key)
+        this.delFromCache(this.s3HeadCache, key)
+      }
+
       await this.opts.s3.deleteObject({
         Key: this._getFullKey(key)
       }).promise()

--- a/src/index.js
+++ b/src/index.js
@@ -140,13 +140,15 @@ class S3Datastore extends Adapter {
       return undefined
     }
 
-    const data = cache.get(this._getFullKey(key))
+    const fullKey = this._getFullKey(key)
+    const data = cache.get(fullKey)
     if (data !== undefined) {
+      console.log(`Got value for ${fullKey} from cache`)
       if (data instanceof Error) {
         throw data
       }
-      return data
     }
+    return data
   }
 
   /**
@@ -160,6 +162,9 @@ class S3Datastore extends Adapter {
     if (!this.cacheEnabled) {
       return
     }
+
+    const fullKey = this._getFullKey(key)
+    console.log(`Put value for ${fullKey} to cache`)
 
     const timeToLive = ttl? ttl : this.cacheTTL
     cache.set(this._getFullKey(key), value, timeToLive)

--- a/src/s3-repo.js
+++ b/src/s3-repo.js
@@ -31,6 +31,8 @@ const createRepo = (S3Store, options, s3Options) => {
   let {
     path,
     createIfMissing,
+    cacheEnabled,
+    cacheTTL,
     lock
   } = options
 
@@ -43,7 +45,9 @@ const createRepo = (S3Store, options, s3Options) => {
       accessKeyId,
       secretAccessKey
     }),
-    createIfMissing
+    createIfMissing,
+    cacheEnabled,
+    cacheTTL
   }
 
   // If no lock is given, create a mock lock

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -167,6 +167,9 @@ describe('S3Datastore', () => {
 
       result = await store.get(new Key('/z/key'))
       expect(result).to.equal(cachedResult)
+
+      const noResult = store.getFromCache(store.s3DataCache, new Key('/z/key1'))
+      expect(noResult).to.equal(undefined)
     })
 
     it('should expire from cache', async () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -134,9 +134,9 @@ describe('S3Datastore', () => {
       return store.get(new Key('/z/key'))
     })
 
-    it('should return a standard not found error code if the key isnt found', async () => {
+    it('should return a standard not found error code if the key isn\'t found', async () => {
       const s3 = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
-      const store = new S3Store('.ipfs/datastore', { s3 })
+      const store = new S3Store('.ipfs/datastore', { s3, cacheEnabled: true })
 
       standin.replace(s3, 'getObject', function (stand, params) {
         expect(params.Key).to.equal('.ipfs/datastore/z/key')
@@ -146,6 +146,12 @@ describe('S3Datastore', () => {
 
       try {
         await store.get(new Key('/z/key'))
+      } catch (err) {
+        expect(err.code).to.equal('ERR_NOT_FOUND')
+      }
+
+      try {
+        store.getFromCache(store.cache, new Key('/z/key'))
       } catch (err) {
         expect(err.code).to.equal('ERR_NOT_FOUND')
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -131,7 +131,11 @@ describe('S3Datastore', () => {
         return s3Resolve({ Body: Buffer.from('test') })
       })
 
-      return store.get(new Key('/z/key'))
+      let result = store.get(new Key('/z/key'))
+      expect(result).to.not.equal(null)
+
+      result = store.getFromCache(store.cache, new Key('/z/key'))
+      expect(result).to.equal(undefined)
     })
 
     it('should return a standard not found error code if the key isn\'t found', async () => {
@@ -211,10 +215,16 @@ describe('S3Datastore', () => {
         return s3Resolve({ Body: Buffer.from('test') })
       })
 
+      standin.replace(s3, 'deleteObject', function (stand, params) {
+        expect(params.Key).to.equal('.ipfs/datastore/z/key')
+        stand.restore()
+        return s3Resolve()
+      })
+
       const result = await store.get(new Key('/z/key'))
       expect(result).to.not.equal(null)
 
-      store.delFromCache(store.cache, new Key('/z/key'))
+      await store.delete(new Key('/z/key'))
 
       const cachedResult = store.getFromCache(store.cache, new Key('/z/key'))
       expect(cachedResult).to.equals(undefined)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -161,8 +161,11 @@ describe('S3Datastore', () => {
         return s3Resolve({ Body: Buffer.from('test') })
       })
 
-      const result = await store.get(new Key('/z/key'))
+      let result = await store.get(new Key('/z/key'))
       const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
+      expect(result).to.equal(cachedResult)
+
+      result = await store.get(new Key('/z/key'))
       expect(result).to.equal(cachedResult)
     })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -172,8 +172,13 @@ describe('S3Datastore', () => {
       })
 
       let result = await store.get(new Key('/z/key'))
+      expect(result).to.not.equal(null)
+
       const cachedResult = store.getFromCache(store.cache, new Key('/z/key'))
-      expect(result).to.equal(cachedResult)
+      expect(cachedResult).to.equal(result)
+
+      result = await store.has(new Key('/z/key'))
+      expect(result).to.equal(true)
 
       result = await store.get(new Key('/z/key'))
       expect(result).to.equal(cachedResult)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -194,6 +194,25 @@ describe('S3Datastore', () => {
       const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
       expect(cachedResult).to.equals(undefined)
     })
+
+    it('should delete from cache', async () => {
+      const s3 = new S3({ params: { Bucket: 'my-ipfs-bucket' } })
+      const store = new S3Store('.ipfs/datastore', { s3, cacheEnabled: true })
+
+      standin.replace(s3, 'getObject', function (stand, params) {
+        expect(params.Key).to.equal('.ipfs/datastore/z/key')
+        stand.restore()
+        return s3Resolve({ Body: Buffer.from('test') })
+      })
+
+      const result = await store.get(new Key('/z/key'))
+      expect(result).to.not.equal(null)
+
+      store.delFromCache(store.s3DataCache, new Key('/z/key'))
+
+      const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
+      expect(cachedResult).to.equals(undefined)
+    })
   })
 
   describe('delete', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -162,13 +162,13 @@ describe('S3Datastore', () => {
       })
 
       let result = await store.get(new Key('/z/key'))
-      const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
+      const cachedResult = store.getFromCache(store.cache, new Key('/z/key'))
       expect(result).to.equal(cachedResult)
 
       result = await store.get(new Key('/z/key'))
       expect(result).to.equal(cachedResult)
 
-      const noResult = store.getFromCache(store.s3DataCache, new Key('/z/key1'))
+      const noResult = store.getFromCache(store.cache, new Key('/z/key1'))
       expect(noResult).to.equal(undefined)
     })
 
@@ -191,7 +191,7 @@ describe('S3Datastore', () => {
 
       await sleep(5)
 
-      const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
+      const cachedResult = store.getFromCache(store.cache, new Key('/z/key'))
       expect(cachedResult).to.equals(undefined)
     })
 
@@ -208,9 +208,9 @@ describe('S3Datastore', () => {
       const result = await store.get(new Key('/z/key'))
       expect(result).to.not.equal(null)
 
-      store.delFromCache(store.s3DataCache, new Key('/z/key'))
+      store.delFromCache(store.cache, new Key('/z/key'))
 
-      const cachedResult = store.getFromCache(store.s3DataCache, new Key('/z/key'))
+      const cachedResult = store.getFromCache(store.cache, new Key('/z/key'))
       expect(cachedResult).to.equals(undefined)
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -186,7 +186,7 @@ describe('S3Datastore', () => {
       expect(result).to.not.equal(null)
 
       const sleep = (ms) => {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise(resolve => setTimeout(resolve, ms))
       }
 
       await sleep(5)


### PR DESCRIPTION
Introduce simple and lightweight caching for the S3 client. The caching library introduced supports timeouts, events and external data sources.

Features:
- enable/disable cache: disabled by default
- configurable TTL: TTLs per cache entry
- support for Node.js and browsers