### PR TITLE
Upgrade to using AWS SDK v3 (Breaking change)

### DIFF
--- a/examples/full-s3-repo/create-s3-repo.js
+++ b/examples/full-s3-repo/create-s3-repo.js
@@ -16,7 +16,7 @@ import * as dagCbor from '@ipld/dag-cbor'
  * A convenience method for creating an S3 backed IPFS repo
  *
  * @param {string} path
- * @param {import('aws-sdk/clients/s3')} s3
+ * @param {import('@aws-sdk/client-s3').S3Client} s3
  * @param {import('ipfs-repo').RepoLock} repoLock
  */
 export const createS3Repo = (path, s3, bucket, repoLock) => {

--- a/examples/full-s3-repo/index.js
+++ b/examples/full-s3-repo/index.js
@@ -4,12 +4,11 @@ import { createS3Repo } from './create-s3-repo'
 import S3 from 'aws-sdk/clients/s3.js'
 import { S3Lock } from './s3-lock'
 
-async function main () {
+const bucket = 'my-bucket'
+
+async function main() {
   // Configure S3 as normal
   const s3 = new S3({
-    params: {
-      Bucket: 'my-bucket'
-    },
     accessKeyId: 'myaccesskey',
     secretAccessKey: 'mysecretkey'
   })
@@ -17,10 +16,10 @@ async function main () {
   // Prevents concurrent access to the repo, you can also use the memory or fs locks
   // bundled with ipfs-repo though they will not prevent processes running on two
   // machines accessing the same repo in parallel
-  const repoLock = new S3Lock(s3)
+  const repoLock = new S3Lock(s3, bucket)
 
   // Create the repo
-  const s3Repo = createS3Repo('/', s3, repoLock)
+  const s3Repo = createS3Repo('/', s3, bucket, repoLock)
 
   // Create a new IPFS node with our S3 backed Repo
   console.log('Start ipfs')
@@ -58,8 +57,7 @@ async function main () {
   await node.stop()
 }
 
-main()
-  .catch(err => {
-    console.error(err)
-    process.exit(1)
-  })
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/full-s3-repo/s3-lock.js
+++ b/examples/full-s3-repo/s3-lock.js
@@ -17,7 +17,7 @@ import {
 
 export class S3Lock {
   /**
-   * @param {import('aws-sdk/clients/s3')} s3
+   * @param {import('@aws-sdk/client-s3').S3Client} s3
    */
   constructor(s3, bucket) {
     this.s3 = s3

--- a/package.json
+++ b/package.json
@@ -165,9 +165,11 @@
     "it-to-buffer": "^3.0.0",
     "uint8arrays": "^4.0.2"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.213.0"
+  },
   "devDependencies": {
     "aegir": "^37.5.1",
-    "aws-sdk": "^2.579.0",
     "interface-datastore-tests": "^3.0.0",
     "sinon": "^14.0.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ import { BaseDatastore } from 'datastore-core/base'
 import * as Errors from 'datastore-core/errors'
 import { fromString as unint8arrayFromString } from 'uint8arrays'
 import toBuffer from 'it-to-buffer'
+import {
+  PutObjectCommand,
+  CreateBucketCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command
+} from '@aws-sdk/client-s3'
 
 /**
  * @typedef {import('interface-datastore').Pair} Pair
@@ -25,29 +33,24 @@ export class S3Datastore extends BaseDatastore {
    * @param {string} path
    * @param {import('./types').S3DatastoreOptions} opts
    */
-  constructor (path, opts) {
+  constructor(path, opts) {
     super()
 
     this.path = path
     this.opts = opts
-    const {
-      createIfMissing = false,
-      s3: {
-        config: {
-          params: {
-            Bucket
-          } = {}
-        } = {}
-      } = {}
-    } = opts
+    const { createIfMissing = false, bucket } = opts
 
-    if (typeof Bucket !== 'string') {
-      throw new Error('An S3 instance with a predefined Bucket must be supplied. See the datastore-s3 README for examples.')
+    if (typeof bucket !== 'string') {
+      throw new Error(
+        'An S3 instance with a predefined Bucket must be supplied. See the datastore-s3 README for examples.'
+      )
     }
     if (typeof createIfMissing !== 'boolean') {
-      throw new Error(`createIfMissing must be a boolean but was (${typeof createIfMissing}) ${createIfMissing}`)
+      throw new Error(
+        `createIfMissing must be a boolean but was (${typeof createIfMissing}) ${createIfMissing}`
+      )
     }
-    this.bucket = Bucket
+    this.bucket = bucket
     this.createIfMissing = createIfMissing
   }
 
@@ -57,7 +60,7 @@ export class S3Datastore extends BaseDatastore {
    * @param {Key} key
    * @returns {string}
    */
-  _getFullKey (key) {
+  _getFullKey(key) {
     // Avoid absolute paths with s3
     return [this.path, key.toString()].join('/').replace(/\/\/+/g, '/')
   }
@@ -69,18 +72,22 @@ export class S3Datastore extends BaseDatastore {
    * @param {Uint8Array} val
    * @returns {Promise<void>}
    */
-  async put (key, val) {
+  async put(key, val) {
     try {
-      await this.opts.s3.upload({
-        Bucket: this.bucket,
-        Key: this._getFullKey(key),
-        Body: Buffer.from(val, val.byteOffset, val.byteLength)
-      }).promise()
+      await this.opts.s3.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: this._getFullKey(key),
+          Body: Buffer.from(val, val.byteOffset, val.byteLength)
+        })
+      )
     } catch (/** @type {any} */ err) {
       if (err.code === 'NoSuchBucket' && this.createIfMissing) {
-        await this.opts.s3.createBucket({
-          Bucket: this.bucket
-        }).promise()
+        await this.opts.s3.send(
+          new CreateBucketCommand({
+            Bucket: this.bucket
+          })
+        )
         return this.put(key, val)
       }
       throw Errors.dbWriteFailedError(err)
@@ -93,36 +100,30 @@ export class S3Datastore extends BaseDatastore {
    * @param {Key} key
    * @returns {Promise<Uint8Array>}
    */
-  async get (key) {
+  async get(key) {
     try {
-      const data = await this.opts.s3.getObject({
-        Bucket: this.bucket,
-        Key: this._getFullKey(key)
-      }).promise()
+      const data = await this.opts.s3.send(
+        new GetObjectCommand({
+          Bucket: this.bucket,
+          Key: this._getFullKey(key)
+        })
+      )
 
       if (!data.Body) {
         throw new Error('Response had no body')
       }
 
-      // If a body was returned, ensure it's a Uint8Array
-      if (data.Body instanceof Uint8Array) {
-        return data.Body
-      }
-
-      if (typeof data.Body === 'string') {
-        return unint8arrayFromString(data.Body)
-      }
-
-      if (data.Body instanceof Blob) {
+      // For browser fetch API that don't support request.body
+      /*if (data.Body instanceof Blob) {
         const buf = await data.Body.arrayBuffer()
 
         return new Uint8Array(buf, 0, buf.byteLength)
-      }
+      }*/
 
-      // @ts-ignore s3 types define their own Blob as an empty interface
-      return await toBuffer(data.Body)
+      // NodeJS >= 17.5.0
+      return Buffer.concat(await data.Body.toArray())
     } catch (/** @type {any} */ err) {
-      if (err.statusCode === 404) {
+      if (err.Code === 'NoSuchKey') {
         throw Errors.notFoundError(err)
       }
       throw err
@@ -134,15 +135,17 @@ export class S3Datastore extends BaseDatastore {
    *
    * @param {Key} key
    */
-  async has (key) {
+  async has(key) {
     try {
-      await this.opts.s3.headObject({
-        Bucket: this.bucket,
-        Key: this._getFullKey(key)
-      }).promise()
+      await this.opts.s3.send(
+        new HeadObjectCommand({
+          Bucket: this.bucket,
+          Key: this._getFullKey(key)
+        })
+      )
       return true
     } catch (/** @type {any} */ err) {
-      if (err.code === 'NotFound') {
+      if (err.$metadata.httpStatusCode === 404) {
         return false
       }
       throw err
@@ -154,12 +157,14 @@ export class S3Datastore extends BaseDatastore {
    *
    * @param {Key} key
    */
-  async delete (key) {
+  async delete(key) {
     try {
-      await this.opts.s3.deleteObject({
-        Bucket: this.bucket,
-        Key: this._getFullKey(key)
-      }).promise()
+      await this.opts.s3.send(
+        new DeleteObjectCommand({
+          Bucket: this.bucket,
+          Key: this._getFullKey(key)
+        })
+      )
     } catch (/** @type {any} */ err) {
       throw Errors.dbDeleteFailedError(err)
     }
@@ -170,16 +175,16 @@ export class S3Datastore extends BaseDatastore {
    *
    * @returns {Batch}
    */
-  batch () {
+  batch() {
     /** @type {({ key: Key, value: Uint8Array })[]} */
     const puts = []
     /** @type {Key[]} */
     const deletes = []
     return {
-      put (key, value) {
+      put(key, value) {
         puts.push({ key: key, value: value })
       },
-      delete (key) {
+      delete(key) {
         deletes.push(key)
       },
       commit: async () => {
@@ -197,12 +202,14 @@ export class S3Datastore extends BaseDatastore {
    * @param {Options} [options]
    * @returns {AsyncGenerator<Key, void, undefined>}
    */
-  async * _listKeys (params, options) {
+  async *_listKeys(params, options) {
     try {
-      const data = await this.opts.s3.listObjectsV2({
-        Bucket: this.bucket,
-        ...params
-      }).promise()
+      const data = await this.opts.s3.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          ...params
+        })
+      )
 
       if (options && options.signal && options.signal.aborted) {
         return
@@ -227,7 +234,7 @@ export class S3Datastore extends BaseDatastore {
         params.StartAfter = data.Contents[data.Contents.length - 1].Key
 
         // recursively fetch keys
-        yield * this._listKeys(params)
+        yield* this._listKeys(params)
       }
     } catch (/** @type {any} */ err) {
       throw new Error(err.code)
@@ -238,7 +245,7 @@ export class S3Datastore extends BaseDatastore {
    * @param {Query} q
    * @param {Options} [options]
    */
-  async * _all (q, options) {
+  async *_all(q, options) {
     for await (const key of this._allKeys({ prefix: q.prefix }, options)) {
       try {
         /** @type {Pair} */
@@ -262,36 +269,41 @@ export class S3Datastore extends BaseDatastore {
    * @param {Options} [options]
    * @returns {AsyncGenerator<Key, void, undefined>}
    */
-  async * _allKeys (q, options) {
+  async *_allKeys(q, options) {
     const prefix = [this.path, q.prefix || ''].join('/').replace(/\/\/+/g, '/')
 
     // Get all the keys via list object, recursively as needed
-    let it = this._listKeys({
-      Prefix: prefix
-    }, options)
+    let it = this._listKeys(
+      {
+        Prefix: prefix
+      },
+      options
+    )
 
     if (q.prefix != null) {
-      it = filter(it, k => k.toString().startsWith(`${q.prefix || ''}`))
+      it = filter(it, (k) => k.toString().startsWith(`${q.prefix || ''}`))
     }
 
-    yield * it
+    yield* it
   }
 
   /**
    * This will check the s3 bucket to ensure access and existence
    */
-  async open () {
+  async open() {
     try {
-      await this.opts.s3.headObject({
-        Bucket: this.bucket,
-        Key: this.path
-      }).promise()
+      await this.opts.s3.send(
+        new HeadObjectCommand({
+          Bucket: this.bucket,
+          Key: this.path
+        })
+      )
     } catch (/** @type {any} */ err) {
-      if (err.statusCode !== 404) {
+      if (err.$metadata.httpStatusCode !== 404) {
         throw Errors.dbOpenFailedError(err)
       }
     }
   }
 
-  async close () {}
+  async close() {}
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,7 @@
-import type S3 from 'aws-sdk/clients/s3'
+import type { S3Client } from 'aws-sdk/client-s3'
 
 export interface S3DatastoreOptions {
-  s3: S3
+  s3: S3Client
+  bucket: string
   createIfMissing?: boolean
 }


### PR DESCRIPTION
Closes #81

TODO
- [ ] Update tests
- [ ] Add NodeJS 16 polyfill if required
- [ ] Update types if needed

Notes:
- `nodejs18.x` deprecated `aws-sdk@2` in favour for `@aws-sdk/*@3` as teh sdk version it's bundled with
- Did not include web support. But can add it in if this is a use case that is expected (Ref: https://transang.me/modern-fetch-and-how-to-get-buffer-output-from-aws-sdk-v3-getobjectcommand/)
- `Bucket` cannot be set in `config.params` on v3 that I know of (See docs https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)

Just want to confirm these changes are welcome before investing more time updating the tests.
